### PR TITLE
Adding keyboard focus outline to allow for keyboard access.

### DIFF
--- a/index.css
+++ b/index.css
@@ -78,6 +78,7 @@ th {
   --teal: #00c2a8;
   --green: #00d66b;
   --lime: #b3db00;
+  --keyboardfocus-color: #000;
 }
 
 html {
@@ -318,7 +319,10 @@ h1 {
     }
   }
 }
-
+.element:focus-within {
+  outline: 2px solid var(--keyboardfocus-color);
+  outline-offset: 2px;
+}
 .pnp-list {
   &[data-mode="picking"] {
     .pnp-item:not(.pnp-clone) {


### PR DESCRIPTION
This is excellent, but keyboard users had no way to know what element they are currently on. Adding focus-within on the element fixes that.
