### PR TITLE
feat: add destroy method and fix CSS transform syntax

### DIFF
--- a/picknplace.js
+++ b/picknplace.js
@@ -367,14 +367,16 @@ export function createPickPlace(options = {}) {
   const transformItems = () => {
     const listRect = state.$list.getBoundingClientRect();
 
+    const indexMap = new Map(
+      state.positions.map((p) => [p.originalIndex, p])
+    );
+
     for (const position of state.positions) {
       const { clone, currentIndex, rect } = position;
 
       let top = rect.top;
 
-      const found = state.positions.find(
-        (pos) => currentIndex === pos.originalIndex
-      );
+      const found = indexMap.get(currentIndex);
 
       if (found && found.originalTop) {
         top = found.originalTop;

--- a/picknplace.js
+++ b/picknplace.js
@@ -44,15 +44,6 @@ export function createPickPlace(options = {}) {
         };
 
       case "place":
-        return {
-          mode: "idle",
-          $list: null,
-          $item: null,
-          originalTop: 0,
-          positions: [],
-          currentIndex: null,
-        };
-
       case "cancel":
         return {
           mode: "idle",

--- a/picknplace.js
+++ b/picknplace.js
@@ -143,7 +143,7 @@ export function createPickPlace(options = {}) {
       position: "fixed",
       width: `${rect.width}px`,
       height: `${rect.height}px`,
-      transform: `translate(${rect.left}px, calc(${rect.top}px + var(--offset))`,
+      transform: `translate(${rect.left}px, calc(${rect.top}px + var(--offset)))`,
     });
     ghostTop = rect.top;
 

--- a/picknplace.js
+++ b/picknplace.js
@@ -406,7 +406,7 @@ export function createPickPlace(options = {}) {
     }
   };
 
-  // Lifecyle
+  // Lifecycle
   const init = () => {
     if (initialized) {
       return;

--- a/picknplace.js
+++ b/picknplace.js
@@ -245,11 +245,11 @@ export function createPickPlace(options = {}) {
     }
   };
 
-  const swapByIndex = (positions, indexA, indexB) => {
+  const swapByIndex = (positions, indexA, indexB, currentIndexMap) => {
     if (indexA === indexB) return;
 
-    const a = positions.find((p) => p.currentIndex === indexA);
-    const b = positions.find((p) => p.currentIndex === indexB);
+    const a = currentIndexMap.get(indexA);
+    const b = currentIndexMap.get(indexB);
 
     if (!a || !b) return;
 
@@ -331,7 +331,10 @@ export function createPickPlace(options = {}) {
       }
 
       if (newTargetIndex !== targetIndex) {
-        swapByIndex(state.positions, targetIndex, newTargetIndex);
+        const currentIndexMap = new Map(
+          state.positions.map((p) => [p.currentIndex, p])
+        );
+        swapByIndex(state.positions, targetIndex, newTargetIndex, currentIndexMap);
         transformItems();
         targetIndex = newTargetIndex;
       }

--- a/picknplace.js
+++ b/picknplace.js
@@ -420,7 +420,32 @@ export function createPickPlace(options = {}) {
     initialized = true;
   };
 
+  const destroy = () => {
+    if (!initialized) {
+      return;
+    }
+
+    if (state.mode === "picking") {
+      dispatch({ type: "cancel" });
+    }
+
+    root.removeEventListener("click", onClick, true);
+    root.removeEventListener("keydown", onKeyDown, true);
+    window.removeEventListener("scroll", onScroll);
+
+    destroyGhost();
+
+    if (scrollRaf) {
+      cancelAnimationFrame(scrollRaf);
+      scrollRaf = null;
+    }
+
+    $controls = null;
+    initialized = false;
+  };
+
   return {
     init,
+    destroy,
   };
 }


### PR DESCRIPTION
Hey @jgthms 👋

Thanks for this neat library! The pick-and-place approach is a great alternative to drag-and-drop.

### Changes

**1. Added `destroy()` method**

Prevents memory leaks by cleaning up event listeners and ghost elements when no longer needed.

**2. Fixed CSS transform syntax**

Missing closing parenthesis in `calc()` was breaking ghost positioning:

- transform: `translate(${x}px, calc(${y}px + var(--offset))`
+ transform: `translate(${x}px, calc(${y}px + var(--offset)))`