### PR TITLE
Recompute picking layout on resize and refine responsive padding

### DIFF
--- a/index.css
+++ b/index.css
@@ -94,7 +94,8 @@ html {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  padding: 0 3em;
+  padding-inline: clamp(1.25em, 4vw, 3em);
+  padding-block: 0;
 }
 
 body,
@@ -205,6 +206,7 @@ main {
   max-width: 21em;
   width: 100%;
   gap: 0;
+  margin-inline: auto;
 }
 
 h1 {
@@ -222,6 +224,9 @@ h1 {
   border-radius: 1em;
   list-style: none;
   position: relative;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .element {
@@ -233,6 +238,8 @@ h1 {
   padding: 0.5em 0.75em;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
+  min-width: 0;
 }
 
 .pnp-list.is-ready {
@@ -261,11 +268,12 @@ h1 {
   right: 0;
   display: flex;
   align-items: center;
-  padding: 2em;
+  padding: clamp(1.25em, 3vw, 2em);
   justify-content: center;
   gap: 1em;
-  top: 100%;
+  bottom: 0;
   opacity: 0;
+  transform: translateY(100%);
   transition-duration: 200ms;
   transition-property: opacity, transform;
   pointer-events: none;
@@ -345,7 +353,7 @@ h1 {
   .pnp-controls {
     &.is-active {
       opacity: 1;
-      transform: translateY(-100%);
+      transform: translateY(0);
       pointer-events: auto;
     }
   }

--- a/picknplace.js
+++ b/picknplace.js
@@ -406,6 +406,37 @@ export function createPickPlace(options = {}) {
     }
   };
 
+  const recomputePickingLayout = () => {
+    if (state.mode !== "picking" || !state.$list || !state.$item) {
+      return;
+    }
+
+    setIdleMode(state.$list);
+    destroyGhost();
+
+    const listRect = state.$list.getBoundingClientRect();
+    const $items = Array.from(state.$list.children).filter(
+      (x) => !x.classList.contains(cloneClass)
+    );
+
+    state.positions = $items.map((el, index) => {
+      const rect = el.getBoundingClientRect();
+
+      return {
+        el,
+        clone: null,
+        originalIndex: index,
+        currentIndex: index,
+        originalTop: rect.top,
+        rect,
+      };
+    });
+
+    state.originalTop = listRect.top;
+    setPickingMode();
+    createGhost(state.$item);
+  };
+
   // Lifecyle
   const init = () => {
     if (initialized) {
@@ -416,6 +447,7 @@ export function createPickPlace(options = {}) {
     root.addEventListener("click", onClick, true);
     root.addEventListener("keydown", onKeyDown, true);
     window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", recomputePickingLayout, { passive: true });
 
     initialized = true;
   };


### PR DESCRIPTION
- Adjust responsive padding and layout spacing to keep controls and content centered across breakpoints.
- Add recomputePickingLayout in picknplace.js to rebuild item positions and ghost elements when the viewport changes, preventing misplaced clones after resize.
- Refresh picking mode setup on resize so dragging behavior stays aligned with the visible list.

Video reference;-
https://www.loom.com/share/06547bc5173e43378f276e9b9a7b9c3a
